### PR TITLE
avoid npm warning: `chrono@1.0.2 package.json: bugs['web'] should probabl

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "url": "git://github.com/kkaefer/chrono.js.git"
     },
     "bugs": {
-        "web": "https://github.com/kkaefer/chrono.js/issues"
+        "url": "https://github.com/kkaefer/chrono.js/issues"
     },
     "main": "index"
 }


### PR DESCRIPTION
avoid npm warning: `chrono@1.0.2 package.json: bugs['web'] should probably be bugs['url']` when installing tilemill
