### PR TITLE
Don't depend on abbreviated timezones. Just use offset.

### DIFF
--- a/lib/chrono.js
+++ b/lib/chrono.js
@@ -380,12 +380,7 @@ Date.prototype.getUTCDayOfYear = function() {
 
 Date.prototype.getTimezone = function() {
   if (!('_tz' in this)) {
-    var matches = new Date().toString().match(/([A-Z]{3,4}|NT|ChST)(?![-\+])/);
-    if (matches && matches[1]) {
-        this.setTimezone(matches[1]);
-    } else {
-        this.setTimezone(new Date().getTimezoneOffset());
-    }
+    this.setTimezone(new Date().getTimezoneOffset());
   }
   return this._tz;
 };


### PR DESCRIPTION
We noticed an issue on mapbox.com where the results of `format` may be `NaN`.  In digging in, I found that we depend on finding an abbreviated timezone from the string output by `new Date().toString()`.  Full details can be found on https://github.com/kkaefer/chrono.js/issues/10#issuecomment-32209224.  

@kkaefer, under which circumstances would we want to derive the timezone from string output by `new Date().toString()` like https://github.com/kkaefer/chrono.js/blob/master/lib/chrono.js#L383-L384 ?  It seems like we'd always just to use `getTimezoneOffset`.  Is this maybe related to IE somehow?  

This is related to https://github.com/mapbox/tilestream-pro/issues/2945#issuecomment-32221258

Refs #10
