### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 node_js:
-  - "0.11"
-  - "0.10"
-  - "0.8"
+  - "12"
+  - "11"
+  - "10"


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.
